### PR TITLE
Save tasks in DB after undo/redo

### DIFF
--- a/shared/redux/rtk-apis/tasksAPI.ts
+++ b/shared/redux/rtk-apis/tasksAPI.ts
@@ -44,7 +44,15 @@ export const api = createApi({
     }),
 
     getTask: builder.query<TTask, string>({
-      query: (id) => `todos/:${id}`,
+      query: (id) => `todos/${id}`,
+    }),
+
+    syncTasks: builder.mutation<void, TTask[]>({
+      query: (tasksData) => ({
+        url: "todos/sync",
+        method: "PUT",
+        body: tasksData,
+      }),
     }),
   }),
 });
@@ -56,4 +64,5 @@ export const {
   useDeleteTaskMutation,
   useDeleteCompletedTaskMutation,
   useGetTaskQuery,
+  useSyncTasksMutation,
 } = api;


### PR DESCRIPTION
### Description of Change
- Added a mutation to store tasks at db
- Called the API after each undo/redo action
### Associated Ticket Link:
- https://trello.com/c/DRK2PyFi
### Related Pull Request: N/A
### Screenshots / Screen Recordings: N/A

